### PR TITLE
Move the dev registry configuration to the nodeConfig.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add the dev registry configuration to the node config so that it will always apply to `/etc/rancher/k3s/registries.yaml` #17
+
 ### Added
 - Packer templates for CES production images
 - Packer templates for CES development images

--- a/image/scripts/dev/docker-registry/all_node_registry.sh
+++ b/image/scripts/dev/docker-registry/all_node_registry.sh
@@ -5,28 +5,10 @@ set -o pipefail
 
 # This file executes settings and installations per K8s node.
 # This file must run as root.
-export REGISTRY_ETC_DIR=/etc/rancher/k3s
-export DOCKER_REGISTRY_DIR=/vagrant/image/scripts/dev/docker-registry
-export REGISTRY_TEMP_DIR=/vagrant/tmp
 export ETC_HOSTS=/etc/hosts
 DOCKER_REGISTRY_PORT=30099
 FQDN="${1}"
 HOST_IP="${2}"
-
-function registerRegistryWithK3s() {
-  local fqdnTemplateVar="REGISTRY_IDENTIFIER"
-  local registryTemplate="${DOCKER_REGISTRY_DIR}/k3s_registry.tmpl.yaml"
-  local registryTemplateRendered="${REGISTRY_TEMP_DIR}/k3s_registry.yaml"
-  local registryTargetPath="${REGISTRY_ETC_DIR}/registries.yaml"
-
-  mkdir -p "${REGISTRY_TEMP_DIR}"
-  mkdir -p "${REGISTRY_ETC_DIR}"
-
-  echo "Registering Registry with K3s"
-  sed "s/${fqdnTemplateVar}/${FQDN}:${DOCKER_REGISTRY_PORT}/g" "${registryTemplate}" > "${registryTemplateRendered}"
-
-  cp "${registryTemplateRendered}" "${registryTargetPath}"
-}
 
 function addEtcHostsEntryForRegistry() {
   local etcHostsExitCode=0
@@ -53,16 +35,9 @@ function echoPushHint() {
 "
 }
 
-function restartK3s() {
-  echo "Restarting k3s to apply registry.yaml..."
-  systemctl restart k3s || systemctl restart k3s-agent
-}
-
 function runSetNode() {
-  registerRegistryWithK3s
   addEtcHostsEntryForRegistry
   echoPushHint
-  restartK3s
 }
 
 # make the script only run when executed, not when sourced from bats tests)

--- a/image/scripts/dev/docker-registry/k3s_registry.tmpl.yaml
+++ b/image/scripts/dev/docker-registry/k3s_registry.tmpl.yaml
@@ -1,8 +1,0 @@
-mirrors:
-  REGISTRY_IDENTIFIER:
-    endpoint:
-      - "http://REGISTRY_IDENTIFIER"
-configs:
-  "REGISTRY_IDENTIFIER":
-    tls:
-      insecure_skip_verify: false

--- a/image/scripts/dev/docker-registry/main_only_registry.sh
+++ b/image/scripts/dev/docker-registry/main_only_registry.sh
@@ -4,10 +4,7 @@ set -o nounset
 set -o pipefail
 
 # This file executes settings and installations only on the K8s main node.
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-export REGISTRY_TEMP_DIR=/vagrant/tmp
 export DOCKER_REGISTRY_DIR=/vagrant/image/scripts/dev/docker-registry
-export DOCKER_NODE_PORT=30099
 
 function deployRegistry() {
   local targetNamespace="${1}"

--- a/image/setup.json
+++ b/image/setup.json
@@ -17,7 +17,7 @@
       "k8s/nginx-ingress",
       "official/cas"
     ],
-    "completed": false
+    "completed": true
   },
   "admin": {
     "username": "admin",

--- a/image/setup.json
+++ b/image/setup.json
@@ -17,7 +17,7 @@
       "k8s/nginx-ingress",
       "official/cas"
     ],
-    "completed": true
+    "completed": false
   },
   "admin": {
     "username": "admin",

--- a/nodeconfig/k3sConfig.json
+++ b/nodeconfig/k3sConfig.json
@@ -27,5 +27,21 @@
       "node-external-ip": "192.168.56.5",
       "flannel-iface": "enp0s8"
     }
-  ]
+  ],
+  "docker-registry-configuration": {
+    "mirrors": {
+      "k3ces.local:30099": {
+        "endpoint": [
+          "http://k3ces.local:30099"
+        ]
+      }
+    },
+    "configs": {
+      "k3ces.local:30099": {
+        "tls": {
+          "insecure_skip_verify": false
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
The k3s-conf service synchronises the k3s registry configuration on every reboot. The http dev mirror configuration was only applied at the first start and was lost after a reload.

Resolves #17 