### PR TITLE
Allow root user to run k9s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable unattended-upgrades
 - Configuration for private registries; #9
 - Install k9s; #11
+- Add env var `KUBECONFIG` to sudoers thereby k9s can be used with `sudo` to edit resources; #21

--- a/image/scripts/dev/host/local_kubeconfig.sh
+++ b/image/scripts/dev/host/local_kubeconfig.sh
@@ -12,7 +12,7 @@ function updateKubectlAccess() {
   echo "Setting up k3ces.local cluster access ..."
   vagrantSetupCluster="$(cat <<EOF
 cd /vagrant \
-&& cp /etc/rancher/k3s/k3s.yaml k3s.yaml
+&& sudo cp /etc/rancher/k3s/k3s.yaml k3s.yaml
 EOF
   )"
 

--- a/image/scripts/installK9s.sh
+++ b/image/scripts/installK9s.sh
@@ -12,6 +12,3 @@ wget -q https://github.com/derailed/k9s/releases/download/${k9sVersion}/k9s_Linu
 echo "${k9sTarSHA256SUM} k9s_Linux_x86_64.tar.gz" | sha256sum --check
 mkdir -p "${installDir}"
 tar xf k9s_Linux_x86_64.tar.gz -C "${installDir}"
-echo "Configuring KUBECONFIG..."
-echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/"${USERNAME}"/.bashrc
-sudo sh -c 'echo "Defaults env_keep += \"KUBECONFIG\"" >> /etc/sudoers'

--- a/image/scripts/installK9s.sh
+++ b/image/scripts/installK9s.sh
@@ -14,3 +14,4 @@ mkdir -p "${installDir}"
 tar xf k9s_Linux_x86_64.tar.gz -C "${installDir}"
 echo "Configuring KUBECONFIG..."
 echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/"${USERNAME}"/.bashrc
+sudo sh -c 'echo "Defaults env_keep += \"KUBECONFIG\"" >> /etc/sudoers'

--- a/resources/usr/sbin/setupMainNode.sh
+++ b/resources/usr/sbin/setupMainNode.sh
@@ -28,6 +28,10 @@ INSTALL_K3S_EXEC="--disable local-storage
  --flannel-iface=${flannelInterface}" \
 /home/"${username}"/install.sh
 
+echo "Configuring KUBECONFIG..."
+echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /etc/environment
+chmod 660 /etc/rancher/k3s/k3s.yaml
+
 echo "Increasing virtual address space for sonar dogu..."
 # see https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
 sysctl -w vm.max_map_count=262144


### PR DESCRIPTION
Add env var KUBECONFIG to sudoers because without it `sudo k9s` can not be used. Without sudo `k9s` can only list resources but can not edit them.

Resolves #21 