### PR TITLE
Support for GPG Encrypted Vagrant Configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ image/output-*
 
 .vagrant
 .vagrant.rb
+.vagrant.rb.asc
 *.log
 
 tmp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,14 @@ basebox_checksum_type = "sha256"
 basebox_url = "https://storage.googleapis.com/cloudogu-ecosystem/basebox-mn/" + basebox_version + "/basebox-mn-" + basebox_version + ".box"
 basebox_name = "basebox-mn-" + basebox_version
 
+# Load gpg encrypted custom configurations from .vagrant.rb.asc file.
+# To encrypt an existing .vgarant.eb file run the following command:
+# gpg --encrypt --armor --default-recipient-self .vagrant.rb
+if File.file?(".vagrant.rb.asc")
+  decrypted = `gpg --decrypt .vagrant.rb.asc`
+  eval decrypted
+end
+
 # Load custom configurations from .vagrant.rb file, if existent
 if File.file?(".vagrant.rb")
   eval File.read(".vagrant.rb")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ basebox_url = "https://storage.googleapis.com/cloudogu-ecosystem/basebox-mn/" + 
 basebox_name = "basebox-mn-" + basebox_version
 
 # Load gpg encrypted custom configurations from .vagrant.rb.asc file.
-# To encrypt an existing .vgarant.eb file run the following command:
+# To encrypt an existing .vgarant.rb file run the following command:
 # gpg --encrypt --armor --default-recipient-self .vagrant.rb
 if File.file?(".vagrant.rb.asc")
   decrypted = `gpg --decrypt .vagrant.rb.asc`

--- a/docs/development/dev_box_de.md
+++ b/docs/development/dev_box_de.md
@@ -39,6 +39,7 @@ Um die Konfiguration in der `.vagrant.rb`-Datei zu verschlüsseln, muss folgende
 ```shell
 gpg --encrypt --armor --default-recipient-self .vagrant.rb
 ```
+Di verschlüsselte Datei hat den Namen `.vagrant.rb.asc`.
 
 Anschließend kann die unverschlüsselte `.vagrant.rb`-Datei gelöscht werden.
 

--- a/docs/development/dev_box_de.md
+++ b/docs/development/dev_box_de.md
@@ -6,9 +6,8 @@ finden.
 
 ### Konfiguration
 
-Die Konfiguration für die Dev-Box erfolgt über eine `.vgarant.rb`-Datei. Diese wird vom `Vagrantfile` eingelesen und
-kann
-die Konfigurationswerte aus dem `Vagrantfile` überschreiben.
+Die Konfiguration für die Dev-Box erfolgt über eine `.vagrant.rb`-Datei. Diese wird vom `Vagrantfile` eingelesen und
+kann die Konfigurationswerte aus dem `Vagrantfile` überschreiben.
 Folgende Konfigurationswerte können (unter anderem) angegeben werden:
 
 | Wert                    | Beschreibung                                        |
@@ -32,17 +31,21 @@ Folgende Konfigurationswerte können (unter anderem) angegeben werden:
 
 Da die Konfiguration sensible Daten enthält, sollte sie nicht Klartext gespeichert werden.
 Daher ist es möglich die Daten mit `gpg` und dem Yubi-Key zu verschlüsseln und so zu speichern.
-Wenn verschlüsselte Konfigurations-Daten vorhanden sind, werden diese vom `Vagrantfile` mit `gpg` und dem Yubi-Key entschlüsselt.
+Wenn verschlüsselte Konfigurations-Daten vorhanden sind, werden diese vom `Vagrantfile` mit `gpg` und dem Yubi-Key
+entschlüsselt.
 
-Um die Konfiguration in der `.vgarant.rb`-Datei zu verschlüsseln, muss folgender Befehl ausgeführt werden:
+Um die Konfiguration in der `.vagrant.rb`-Datei zu verschlüsseln, muss folgender Befehl ausgeführt werden:
+
 ```shell
 gpg --encrypt --armor --default-recipient-self .vagrant.rb
 ```
-Anschließend kann die unverschlüsselte `.vgarant.rb`-Datei gelöscht werden.
+
+Anschließend kann die unverschlüsselte `.vagrant.rb`-Datei gelöscht werden.
 
 Zum Entschlüssen kann folgender Befehl verwendet werden:
+
 ```shell
 gpg --decrypt .vagrant.rb.asc > .vagrant.rb
 ```
 
-> **Hinweis:** Bei Änderungen in der `.vgarant.rb` muss diese erneut verschlüsselt und anschließend gelöscht werden! 
+> **Hinweis:** Bei Änderungen in der `.vagrant.rb` muss diese erneut verschlüsselt und anschließend gelöscht werden! 

--- a/docs/development/dev_box_de.md
+++ b/docs/development/dev_box_de.md
@@ -1,0 +1,48 @@
+# Dev-Box
+
+Dieses Dokument enthält die notwendigen Informationen, um die Entwicklungs-Basebox lokal mit Vagrant zu starten.
+Eine Anleitung für die Erstellung des Images für die Entwicklungs-Basebox ist [hier](./building_basebox_de.md) zu
+finden.
+
+### Konfiguration
+
+Die Konfiguration für die Dev-Box erfolgt über eine `.vgarant.rb`-Datei. Diese wird vom `Vagrantfile` eingelesen und
+kann
+die Konfigurationswerte aus dem `Vagrantfile` überschreiben.
+Folgende Konfigurationswerte können (unter anderem) angegeben werden:
+
+| Wert                    | Beschreibung                                        |
+|-------------------------|-----------------------------------------------------|
+| dogu_registry_url       | Die URL der Dogu-Registry                           |
+| dogu_registry_username  | Der Benutzername zu Login in die Dogu-Registry      |
+| dogu_registry_password  | Das Passwort zu Login in die Dogu-Registry          |
+| image_registry_url      | Die URL der Image-Registry                          |
+| image_registry_username | Der Benutzername zu Login in die Image-Registry     |
+| image_registry_password | Das Passwort zu Login in die Image-Registry         |
+| image_registry_email    | Die E-Mail-Adresse des Benutzers der Image-Registry |
+| helm_registry_url       | Die URL der Helm-Registry                           |
+| helm_registry_username  | Der Benutzername zu Login in die Helm-Registry      |
+| helm_registry_password  | Das Passwort zu Login in die Helm-Registry          |
+| vm_memory               | Der Arbeitsspeicher der VMs                         |
+| vm_cpus                 | Die Anzahl der CPUs der VMs                         |
+| worker_count            | Die Anzahl der Worker-Nodes des Cluster             |
+| main_k3s_ip_address     | Die IP-Adresse des Main-Nodes des Cluster           |
+
+#### Verschlüsselung der Konfiguration
+
+Da die Konfiguration sensible Daten enthält, sollte sie nicht Klartext gespeichert werden.
+Daher ist es möglich die Daten mit `gpg` und dem Yubi-Key zu verschlüsseln und so zu speichern.
+Wenn verschlüsselte Konfigurations-Daten vorhanden sind, werden diese vom `Vagrantfile` mit `gpg` und dem Yubi-Key entschlüsselt.
+
+Um die Konfiguration in der `.vgarant.rb`-Datei zu verschlüsseln, muss folgender Befehl ausgeführt werden:
+```shell
+gpg --encrypt --armor --default-recipient-self .vagrant.rb
+```
+Anschließend kann die unverschlüsselte `.vgarant.rb`-Datei gelöscht werden.
+
+Zum Entschlüssen kann folgender Befehl verwendet werden:
+```shell
+gpg --decrypt .vagrant.rb.asc > .vagrant.rb
+```
+
+> **Hinweis:** Bei Änderungen in der `.vgarant.rb` muss diese erneut verschlüsselt und anschließend gelöscht werden! 

--- a/docs/development/dev_box_en.md
+++ b/docs/development/dev_box_en.md
@@ -1,0 +1,47 @@
+# Dev Box
+
+This document contains the necessary information to start the development basebox locally with Vagrant.
+Instructions for building the image for the development basebox can be found [here](./building_basebox_en.md).
+
+### Configuration
+
+The configuration for the dev box is done via a `.vgarant.rb` file. This is read in from the `Vagrantfile` and can
+overwrite the configuration values from the `Vagrantfile`.
+The following configuration values can be specified (among others):
+
+| value                   | description                                    |
+|-------------------------|------------------------------------------------|
+| dogu_registry_url       | The URL of the dogu registry                   |
+| dogu_registry_username  | The username to login to the dogu registry     |
+| dogu_registry_password  | The password to login to the Dogu Registry     |
+| image_registry_url      | The URL of the image registry                  |
+| image_registry_username | The username to login to the image registry    |
+| image_registry_password | The password to login to the image registry    |
+| image_registry_email    | The e-mail address of the image registry user  |
+| helm_registry_url       | URL of the helmet registry                     |
+| helm_registry_username  | The username to login to the helmet registry   |
+| helm_registry_password  | The password to login to the helmet registry   |
+| vm_memory               | The VMs memory                                 |
+| vm_cpus                 | The number of CPUs in the VMs                  |
+| worker_count            | The number of worker nodes of the cluster      |
+| main_k3s_ip_address     | The IP address of the main node of the cluster |
+
+#### Encryption of the configuration
+
+Since the configuration contains sensitive data, it should not be stored in plain text.
+Therefore it is possible to encrypt the data with `gpg` and the Yubi key and store it this way.
+If encrypted configuration data is present, it will be decrypted from the `vagrantfile` with `gpg` and the Yubi key.
+
+To encrypt the configuration in the `.vgarant.rb` file, the following command must be executed:
+```shell
+gpg --encrypt --armor --default-recipient-self .vagrant.rb
+
+```
+Then the unencrypted `.vgarant.rb` file can be deleted.
+
+The following command can be used to decrypt it:
+```shell
+gpg --decrypt .vagrant.rb.asc > .vagrant.rb
+```
+
+> **Note:** If changes are made to the `.vgarant.rb`, it must be re-encrypted and then deleted!

--- a/docs/development/dev_box_en.md
+++ b/docs/development/dev_box_en.md
@@ -38,6 +38,7 @@ To encrypt the configuration in the `.vagrant.rb` file, the following command mu
 gpg --encrypt --armor --default-recipient-self .vagrant.rb
 
 ```
+The encrypted file is named `.vagrant.rb.asc`.
 
 Then the unencrypted `.vagrant.rb` file can be deleted.
 

--- a/docs/development/dev_box_en.md
+++ b/docs/development/dev_box_en.md
@@ -5,7 +5,7 @@ Instructions for building the image for the development basebox can be found [he
 
 ### Configuration
 
-The configuration for the dev box is done via a `.vgarant.rb` file. This is read in from the `Vagrantfile` and can
+The configuration for the dev box is done via a `.vagrant.rb` file. This is read in from the `Vagrantfile` and can
 overwrite the configuration values from the `Vagrantfile`.
 The following configuration values can be specified (among others):
 
@@ -13,14 +13,14 @@ The following configuration values can be specified (among others):
 |-------------------------|------------------------------------------------|
 | dogu_registry_url       | The URL of the dogu registry                   |
 | dogu_registry_username  | The username to login to the dogu registry     |
-| dogu_registry_password  | The password to login to the Dogu Registry     |
+| dogu_registry_password  | The password to login to the dogu Registry     |
 | image_registry_url      | The URL of the image registry                  |
 | image_registry_username | The username to login to the image registry    |
 | image_registry_password | The password to login to the image registry    |
 | image_registry_email    | The e-mail address of the image registry user  |
-| helm_registry_url       | URL of the helmet registry                     |
-| helm_registry_username  | The username to login to the helmet registry   |
-| helm_registry_password  | The password to login to the helmet registry   |
+| helm_registry_url       | URL of the helm registry                       |
+| helm_registry_username  | The username to login to the helm registry     |
+| helm_registry_password  | The password to login to the helm registry     |
 | vm_memory               | The VMs memory                                 |
 | vm_cpus                 | The number of CPUs in the VMs                  |
 | worker_count            | The number of worker nodes of the cluster      |
@@ -32,16 +32,19 @@ Since the configuration contains sensitive data, it should not be stored in plai
 Therefore it is possible to encrypt the data with `gpg` and the Yubi key and store it this way.
 If encrypted configuration data is present, it will be decrypted from the `vagrantfile` with `gpg` and the Yubi key.
 
-To encrypt the configuration in the `.vgarant.rb` file, the following command must be executed:
+To encrypt the configuration in the `.vagrant.rb` file, the following command must be executed:
+
 ```shell
 gpg --encrypt --armor --default-recipient-self .vagrant.rb
 
 ```
-Then the unencrypted `.vgarant.rb` file can be deleted.
+
+Then the unencrypted `.vagrant.rb` file can be deleted.
 
 The following command can be used to decrypt it:
+
 ```shell
 gpg --decrypt .vagrant.rb.asc > .vagrant.rb
 ```
 
-> **Note:** If changes are made to the `.vgarant.rb`, it must be re-encrypted and then deleted!
+> **Note:** If changes are made to the `.vagrant.rb`, it must be re-encrypted and then deleted!


### PR DESCRIPTION
Allow loading of an gpg encrypted vagrant configuration. This is especially useful if sensitive information, such as credentials are stored in the configuration.

The encrypted configuration can be used together with the unencrypted configuration. The encrypted configuration must use the gpg armor format, is stored in the root of the repository and is called `.vagrant.rb.asc`. To encrypt an existing `.vagrant.rb` file, the following command can be used:

`gpg --encrypt --armor --default-recipient-self .vagrant.rb`  